### PR TITLE
move internal dependencies into optionalDependencies so they dont cau…

### DIFF
--- a/sp-privacy/package-lock.json
+++ b/sp-privacy/package-lock.json
@@ -1,29 +1,32 @@
 {
   "name": "sp-privacy",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "name": "sp-privacy",
+      "version": "0.1.1",
       "devDependencies": {
-        "@s1/eslint-config": "11.0.1",
-        "@s1/prettier-config": "4.0.0",
-        "@types/firefox-webext-browser": "82.0.0",
-        "@types/node": "^14.14.31",
         "copyfiles": "2.4.1",
         "fs": "0.0.1-security",
         "prettier": "2.2.1",
         "typescript": "^4.1.5",
         "webextension-polyfill": "0.7.0"
+      },
+      "optionalDependencies": {
+        "@s1/eslint-config": "11.0.1",
+        "@s1/prettier-config": "4.0.0",
+        "@types/firefox-webext-browser": "82.0.0",
+        "@types/node": "^14.14.31"
       }
     },
     "node_modules/@babel/runtime": {
       "version": "7.13.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@babel/runtime/-/runtime-7.13.6.tgz",
       "integrity": "sha1-huD61su0amgOIcGqR0hxegWNNFo=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -32,8 +35,8 @@
       "version": "11.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@s1/eslint-config/-/@s1/eslint-config-11.0.1.tgz",
       "integrity": "sha1-i+sHflXtHBWGzFygfgai3qz+DqI=",
-      "dev": true,
       "license": "UNLICENSED",
+      "optional": true,
       "dependencies": {
         "@s1/prettier-config": "4.x",
         "@typescript-eslint/eslint-plugin": "2.10.0",
@@ -60,43 +63,43 @@
       "version": "4.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@s1/prettier-config/-/@s1/prettier-config-4.0.0.tgz",
       "integrity": "sha1-51uLo6yrf+Z7NxXjdLyglHLDUtc=",
-      "dev": true,
-      "license": "UNLICENSED"
+      "license": "UNLICENSED",
+      "optional": true
     },
     "node_modules/@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/firefox-webext-browser": {
       "version": "82.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.0.tgz",
       "integrity": "sha1-TQ9c/r1zIdLL8Mz7YDJXDwE4uVg=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha1-mKmTUWyFnrDVxMjwmDF6nqaNua0=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/node": {
       "version": "14.14.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
       "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz",
       "integrity": "sha1-xMsQMnXlVein6bPRTFlR621DHnA=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@typescript-eslint/experimental-utils": "2.10.0",
         "eslint-utils": "^1.4.3",
@@ -121,8 +124,8 @@
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
       "integrity": "sha1-jbFlbN/T2dy9vzYLgnTep28LLCw=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "2.10.0",
@@ -139,8 +142,8 @@
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/parser/-/parser-2.10.0.tgz",
       "integrity": "sha1-JLLkg4SrbVphIeTE+viJLHlletM=",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "@types/eslint-visitor-keys": "^1.0.0",
         "@typescript-eslint/experimental-utils": "2.10.0",
@@ -158,8 +161,8 @@
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
       "integrity": "sha1-ic2r1ejHdOnVkFiMtC+5r9FNy9k=",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -208,8 +211,8 @@
       "version": "3.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/aria-query/-/aria-query-3.0.0.tgz",
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "ast-types-flow": "0.0.7",
         "commander": "^2.11.0"
@@ -219,8 +222,8 @@
       "version": "3.1.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/array-includes/-/array-includes-3.1.3.tgz",
       "integrity": "sha1-x/YZs4KtKvr1Mmzd/cCvxhr3aQo=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -239,28 +242,28 @@
       "version": "0.0.7",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
-      "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha1-lD1H4QwLcEqkInXiDt83ImSJib4=",
-      "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "optional": true
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -271,8 +274,8 @@
       "version": "1.0.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -317,22 +320,22 @@
       "version": "2.20.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/commander/-/commander-2.20.3.tgz",
       "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.10",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
       "integrity": "sha1-MNHn89G4grJexJM9HRraw1PSClk=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/copyfiles": {
       "version": "2.4.1",
@@ -365,15 +368,15 @@
       "version": "1.0.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
       "integrity": "sha1-FDwWQcs9hcYMMjKeJoma3qhwF5E=",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "optional": true
     },
     "node_modules/debug": {
       "version": "4.3.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/debug/-/debug-4.3.1.tgz",
       "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -390,8 +393,8 @@
       "version": "1.1.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "object-keys": "^1.0.12"
       },
@@ -403,15 +406,15 @@
       "version": "7.0.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/es-abstract": {
       "version": "1.18.0-next.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
       "integrity": "sha1-CIEBpV8FQfWV5+BXGZ4n3cjzpcI=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -439,8 +442,8 @@
       "version": "1.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -467,8 +470,8 @@
       "version": "18.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
       "integrity": "sha1-t/4rQvn4Fz6CW3PIAUtZLkScmNk=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eslint-config-airbnb-base": "^14.2.1",
         "object.assign": "^4.1.2",
@@ -489,8 +492,8 @@
       "version": "14.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
       "integrity": "sha1-ii6zhFXcWjElUBk7MZza7vBCzR4=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -508,8 +511,8 @@
       "version": "5.1.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-config-react-app/-/eslint-config-react-app-5.1.0.tgz",
       "integrity": "sha1-o3s/LU9W+Fb5MncoHvUr15EnPmM=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "confusing-browser-globals": "^1.0.9"
       },
@@ -529,8 +532,8 @@
       "version": "6.2.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
       "integrity": "sha1-uHKgnV3lGvcKl9se6n3JMwQ3CKo=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
@@ -553,8 +556,8 @@
       "version": "5.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -567,8 +570,8 @@
       "version": "1.4.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "eslint-visitor-keys": "^1.1.0"
       },
@@ -580,8 +583,8 @@
       "version": "1.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
-      "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -590,8 +593,8 @@
       "version": "4.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -603,8 +606,8 @@
       "version": "5.2.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
       "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -613,8 +616,8 @@
       "version": "4.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
-      "dev": true,
       "license": "BSD-2-Clause",
+      "optional": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -630,22 +633,22 @@
       "version": "1.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -661,8 +664,8 @@
       "version": "1.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -676,7 +679,7 @@
       "version": "7.1.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -697,8 +700,8 @@
       "version": "1.0.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -710,8 +713,8 @@
       "version": "1.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -723,7 +726,7 @@
       "version": "1.0.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -734,15 +737,15 @@
       "version": "2.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/is-callable": {
       "version": "1.2.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-callable/-/is-callable-1.2.3.tgz",
       "integrity": "sha1-ix4FALc6HXbHBIdjbzaOUZ3o244=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -754,8 +757,8 @@
       "version": "1.0.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -767,8 +770,8 @@
       "version": "2.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -787,8 +790,8 @@
       "version": "4.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -800,8 +803,8 @@
       "version": "2.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -813,8 +816,8 @@
       "version": "1.1.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-regex/-/is-regex-1.1.2.tgz",
       "integrity": "sha1-gcjr3k2xQvLPHFP8htakV4gmYlE=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
@@ -830,8 +833,8 @@
       "version": "1.0.5",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha1-QEk+0ZjvP/R3uMf5L2ROyCpc06Y=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -843,8 +846,8 @@
       "version": "1.0.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "has-symbols": "^1.0.1"
       },
@@ -866,8 +869,8 @@
       "version": "2.4.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
       "integrity": "sha1-ERSkwSCUgdsGxpDCtPSIzGZfZX4=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
@@ -880,14 +883,14 @@
       "version": "4.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/minimatch": {
       "version": "3.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -913,8 +916,8 @@
       "version": "2.1.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/ms/-/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/noms": {
       "version": "0.0.0",
@@ -931,8 +934,8 @@
       "version": "1.9.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object-inspect/-/object-inspect-1.9.0.tgz",
       "integrity": "sha1-yQUh104RJ7ZyZt7TOUrWEWmGUzo=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -941,8 +944,8 @@
       "version": "1.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -951,8 +954,8 @@
       "version": "4.1.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -970,8 +973,8 @@
       "version": "1.1.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object.entries/-/object.entries-1.1.3.tgz",
       "integrity": "sha1-xgHH8Wi2I3RUGgfdvT4tXk93EaY=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -986,7 +989,7 @@
       "version": "1.4.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -996,7 +999,7 @@
       "version": "1.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1006,7 +1009,7 @@
       "version": "2.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha1-eVoaeN1S8HPaDNQrIfnJE4GSP/U=",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "prettier": "bin-prettier.js"
@@ -1039,15 +1042,15 @@
       "version": "0.13.7",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/regexpp": {
       "version": "3.1.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=8"
       },
@@ -1076,8 +1079,8 @@
       "version": "6.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/semver/-/semver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
-      "dev": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -1115,8 +1118,8 @@
       "version": "1.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -1129,8 +1132,8 @@
       "version": "1.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -1200,15 +1203,15 @@
       "version": "1.14.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
-      "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsutils": {
       "version": "3.20.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/tsutils/-/tsutils-3.20.0.tgz",
       "integrity": "sha1-6gPqRUYuFGtT1wzgiT3kU/8k9pg=",
-      "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "tslib": "^1.8.1"
       },
@@ -1223,7 +1226,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
       "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -1279,7 +1282,7 @@
       "version": "1.0.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/xtend": {
@@ -1337,7 +1340,7 @@
       "version": "7.13.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@babel/runtime/-/runtime-7.13.6.tgz",
       "integrity": "sha1-huD61su0amgOIcGqR0hxegWNNFo=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1346,7 +1349,7 @@
       "version": "11.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@s1/eslint-config/-/@s1/eslint-config-11.0.1.tgz",
       "integrity": "sha1-i+sHflXtHBWGzFygfgai3qz+DqI=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@s1/prettier-config": "4.x",
         "@typescript-eslint/eslint-plugin": "2.10.0",
@@ -1360,37 +1363,37 @@
       "version": "4.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@s1/prettier-config/-/@s1/prettier-config-4.0.0.tgz",
       "integrity": "sha1-51uLo6yrf+Z7NxXjdLyglHLDUtc=",
-      "dev": true
+      "optional": true
     },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "integrity": "sha1-HuMNeVRMqE1o1LPNsK9PIFZj3S0=",
-      "dev": true
+      "optional": true
     },
     "@types/firefox-webext-browser": {
       "version": "82.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@types/firefox-webext-browser/-/firefox-webext-browser-82.0.0.tgz",
       "integrity": "sha1-TQ9c/r1zIdLL8Mz7YDJXDwE4uVg=",
-      "dev": true
+      "optional": true
     },
     "@types/json-schema": {
       "version": "7.0.7",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@types/json-schema/-/json-schema-7.0.7.tgz",
       "integrity": "sha1-mKmTUWyFnrDVxMjwmDF6nqaNua0=",
-      "dev": true
+      "optional": true
     },
     "@types/node": {
       "version": "14.14.31",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
       "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g==",
-      "dev": true
+      "optional": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz",
       "integrity": "sha1-xMsQMnXlVein6bPRTFlR621DHnA=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@typescript-eslint/experimental-utils": "2.10.0",
         "eslint-utils": "^1.4.3",
@@ -1403,7 +1406,7 @@
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
       "integrity": "sha1-jbFlbN/T2dy9vzYLgnTep28LLCw=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
         "@typescript-eslint/typescript-estree": "2.10.0",
@@ -1414,7 +1417,7 @@
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/parser/-/parser-2.10.0.tgz",
       "integrity": "sha1-JLLkg4SrbVphIeTE+viJLHlletM=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
         "@typescript-eslint/experimental-utils": "2.10.0",
@@ -1426,7 +1429,7 @@
       "version": "2.10.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
       "integrity": "sha1-ic2r1ejHdOnVkFiMtC+5r9FNy9k=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -1456,7 +1459,7 @@
       "version": "3.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/aria-query/-/aria-query-3.0.0.tgz",
       "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ast-types-flow": "0.0.7",
         "commander": "^2.11.0"
@@ -1466,7 +1469,7 @@
       "version": "3.1.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/array-includes/-/array-includes-3.1.3.tgz",
       "integrity": "sha1-x/YZs4KtKvr1Mmzd/cCvxhr3aQo=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3",
@@ -1479,25 +1482,25 @@
       "version": "0.0.7",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
       "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
-      "dev": true
+      "optional": true
     },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/axobject-query/-/axobject-query-2.2.0.tgz",
       "integrity": "sha1-lD1H4QwLcEqkInXiDt83ImSJib4=",
-      "dev": true
+      "optional": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "devOptional": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1507,7 +1510,7 @@
       "version": "1.0.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -1543,19 +1546,19 @@
       "version": "2.20.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/commander/-/commander-2.20.3.tgz",
       "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
-      "dev": true
+      "optional": true
     },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "devOptional": true
     },
     "confusing-browser-globals": {
       "version": "1.0.10",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
       "integrity": "sha1-MNHn89G4grJexJM9HRraw1PSClk=",
-      "dev": true
+      "optional": true
     },
     "copyfiles": {
       "version": "2.4.1",
@@ -1582,13 +1585,13 @@
       "version": "1.0.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz",
       "integrity": "sha1-FDwWQcs9hcYMMjKeJoma3qhwF5E=",
-      "dev": true
+      "optional": true
     },
     "debug": {
       "version": "4.3.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/debug/-/debug-4.3.1.tgz",
       "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "ms": "2.1.2"
       }
@@ -1597,7 +1600,7 @@
       "version": "1.1.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -1606,13 +1609,13 @@
       "version": "7.0.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
-      "dev": true
+      "optional": true
     },
     "es-abstract": {
       "version": "1.18.0-next.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
       "integrity": "sha1-CIEBpV8FQfWV5+BXGZ4n3cjzpcI=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "es-to-primitive": "^1.2.1",
@@ -1634,7 +1637,7 @@
       "version": "1.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -1651,7 +1654,7 @@
       "version": "18.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
       "integrity": "sha1-t/4rQvn4Fz6CW3PIAUtZLkScmNk=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.2.1",
         "object.assign": "^4.1.2",
@@ -1662,7 +1665,7 @@
       "version": "14.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
       "integrity": "sha1-ii6zhFXcWjElUBk7MZza7vBCzR4=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "confusing-browser-globals": "^1.0.10",
         "object.assign": "^4.1.2",
@@ -1673,7 +1676,7 @@
       "version": "5.1.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-config-react-app/-/eslint-config-react-app-5.1.0.tgz",
       "integrity": "sha1-o3s/LU9W+Fb5MncoHvUr15EnPmM=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "confusing-browser-globals": "^1.0.9"
       }
@@ -1682,7 +1685,7 @@
       "version": "6.2.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.3.tgz",
       "integrity": "sha1-uHKgnV3lGvcKl9se6n3JMwQ3CKo=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "@babel/runtime": "^7.4.5",
         "aria-query": "^3.0.0",
@@ -1699,7 +1702,7 @@
       "version": "5.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-scope/-/eslint-scope-5.1.1.tgz",
       "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -1709,7 +1712,7 @@
       "version": "1.4.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-utils/-/eslint-utils-1.4.3.tgz",
       "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
@@ -1718,13 +1721,13 @@
       "version": "1.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
-      "dev": true
+      "optional": true
     },
     "esrecurse": {
       "version": "4.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "estraverse": "^5.2.0"
       },
@@ -1733,7 +1736,7 @@
           "version": "5.2.0",
           "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/estraverse/-/estraverse-5.2.0.tgz",
           "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
-          "dev": true
+          "optional": true
         }
       }
     },
@@ -1741,7 +1744,7 @@
       "version": "4.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/estraverse/-/estraverse-4.3.0.tgz",
       "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
-      "dev": true
+      "optional": true
     },
     "fs": {
       "version": "0.0.1-security",
@@ -1753,19 +1756,19 @@
       "version": "1.0.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "devOptional": true
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true
+      "optional": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-      "dev": true
+      "optional": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -1777,7 +1780,7 @@
       "version": "1.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
       "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
@@ -1788,7 +1791,7 @@
       "version": "7.1.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1802,7 +1805,7 @@
       "version": "1.0.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -1811,13 +1814,13 @@
       "version": "1.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
-      "dev": true
+      "optional": true
     },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1827,25 +1830,25 @@
       "version": "2.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "dev": true
+      "devOptional": true
     },
     "is-callable": {
       "version": "1.2.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-callable/-/is-callable-1.2.3.tgz",
       "integrity": "sha1-ix4FALc6HXbHBIdjbzaOUZ3o244=",
-      "dev": true
+      "optional": true
     },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-date-object/-/is-date-object-1.0.2.tgz",
       "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
-      "dev": true
+      "optional": true
     },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
+      "optional": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -1857,7 +1860,7 @@
       "version": "4.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-glob/-/is-glob-4.0.1.tgz",
       "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -1866,13 +1869,13 @@
       "version": "2.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
       "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=",
-      "dev": true
+      "optional": true
     },
     "is-regex": {
       "version": "1.1.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-regex/-/is-regex-1.1.2.tgz",
       "integrity": "sha1-gcjr3k2xQvLPHFP8htakV4gmYlE=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "has-symbols": "^1.0.1"
@@ -1882,13 +1885,13 @@
       "version": "1.0.5",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha1-QEk+0ZjvP/R3uMf5L2ROyCpc06Y=",
-      "dev": true
+      "optional": true
     },
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -1903,7 +1906,7 @@
       "version": "2.4.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
       "integrity": "sha1-ERSkwSCUgdsGxpDCtPSIzGZfZX4=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
@@ -1913,13 +1916,13 @@
       "version": "4.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
+      "optional": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1934,7 +1937,7 @@
       "version": "2.1.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/ms/-/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-      "dev": true
+      "optional": true
     },
     "noms": {
       "version": "0.0.0",
@@ -1950,19 +1953,19 @@
       "version": "1.9.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object-inspect/-/object-inspect-1.9.0.tgz",
       "integrity": "sha1-yQUh104RJ7ZyZt7TOUrWEWmGUzo=",
-      "dev": true
+      "optional": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true
+      "optional": true
     },
     "object.assign": {
       "version": "4.1.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object.assign/-/object.assign-4.1.2.tgz",
       "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -1974,7 +1977,7 @@
       "version": "1.1.3",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/object.entries/-/object.entries-1.1.3.tgz",
       "integrity": "sha1-xgHH8Wi2I3RUGgfdvT4tXk93EaY=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
@@ -1986,7 +1989,7 @@
       "version": "1.4.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1995,13 +1998,13 @@
       "version": "1.0.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "devOptional": true
     },
     "prettier": {
       "version": "2.2.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/prettier/-/prettier-2.2.1.tgz",
       "integrity": "sha1-eVoaeN1S8HPaDNQrIfnJE4GSP/U=",
-      "dev": true
+      "devOptional": true
     },
     "process-nextick-args": {
       "version": "2.0.1",
@@ -2025,13 +2028,13 @@
       "version": "0.13.7",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
       "integrity": "sha1-ysLazIoepnX+qrrriugziYrkb1U=",
-      "dev": true
+      "optional": true
     },
     "regexpp": {
       "version": "3.1.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/regexpp/-/regexpp-3.1.0.tgz",
       "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
-      "dev": true
+      "optional": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -2049,7 +2052,7 @@
       "version": "6.3.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/semver/-/semver-6.3.0.tgz",
       "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
-      "dev": true
+      "optional": true
     },
     "string_decoder": {
       "version": "0.10.31",
@@ -2080,7 +2083,7 @@
       "version": "1.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
       "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -2090,7 +2093,7 @@
       "version": "1.0.4",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
       "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
@@ -2151,13 +2154,13 @@
       "version": "1.14.1",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
-      "dev": true
+      "optional": true
     },
     "tsutils": {
       "version": "3.20.0",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/tsutils/-/tsutils-3.20.0.tgz",
       "integrity": "sha1-6gPqRUYuFGtT1wzgiT3kU/8k9pg=",
-      "dev": true,
+      "optional": true,
       "requires": {
         "tslib": "^1.8.1"
       }
@@ -2166,7 +2169,7 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.5.tgz",
       "integrity": "sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==",
-      "dev": true
+      "devOptional": true
     },
     "untildify": {
       "version": "4.0.0",
@@ -2201,7 +2204,7 @@
       "version": "1.0.2",
       "resolved": "https://system1.jfrog.io/system1/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "devOptional": true
     },
     "xtend": {
       "version": "4.0.2",

--- a/sp-privacy/package.json
+++ b/sp-privacy/package.json
@@ -5,11 +5,13 @@
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "dependencies": {},
-  "devDependencies": {
+  "optionalDependencies": {
     "@s1/eslint-config": "11.0.1",
     "@s1/prettier-config": "4.0.0",
     "@types/firefox-webext-browser": "82.0.0",
-    "@types/node": "^14.14.31",
+    "@types/node": "^14.14.31"
+  },
+  "devDependencies": {
     "copyfiles": "2.4.1",
     "fs": "0.0.1-security",
     "prettier": "2.2.1",


### PR DESCRIPTION
This change moves s1 internal npm packages in `sp-privacy/package-lock.json` into the `optionalDependencies` block so that firefox developers who are reviewing our source code for the privacy-search extension can run npm install without needing to authenticate with our npm registry.

Basically, moving these internal packages into the `optionalDependencies` block prevents `npm install` from failing when npm fails to find these packages in the npm registry.

This PR is complementary to https://github.com/Openmail/system1/pull/52295